### PR TITLE
#163682802 Delete Party - API

### DIFF
--- a/app/version1/modules/party_module.py
+++ b/app/version1/modules/party_module.py
@@ -123,3 +123,15 @@ class PoliticalParty():
                     break
 
         return [{"id":self.party_id, "name":new_party_data["party_name"]}]
+
+
+    def delete_political_party(self):
+        if PoliticalParty.check_existence(self, "party_id", self.party_id) == False:
+            abort(400)
+        else:
+            party_data = self.party_data
+            for i in party_data:
+                if i.get("party_id") == self.party_id:
+                    party_data.remove(i)
+                    break
+            return ["deletion successful"]

--- a/app/version1/views/admin.py
+++ b/app/version1/views/admin.py
@@ -85,3 +85,17 @@ def edit_political_party(party_id):
         "status": 201,
         "data": updated_party
     }), 201)
+
+
+# get a specific political party
+@bp.route('/api/v1/delete-political-party/<int:party_id>', methods=['DELETE'])
+def delete_political_party(party_id):
+
+    DELETE_POLITICAL_PARTY = PoliticalParty(party_id=party_id, party_data=party_list)
+
+    message = DELETE_POLITICAL_PARTY.delete_political_party()
+
+    return make_response(jsonify({
+        "status": 201,
+        "message": message,
+    }), 201)

--- a/tests/test_partyapi.py
+++ b/tests/test_partyapi.py
@@ -44,7 +44,7 @@ def test_validate_existing_data(client):
 
 # test to validate empty data
 def test_validate_empty_data(client):
-    """ Tests whether the api can create a calid request """
+    """ Tests whether the api can create an invalid request """
     party_data = {
 	           "id": 5,
                "name": "",
@@ -94,3 +94,13 @@ def test_edit_political_party(client):
     response = client.patch(url, json=party_data)
     assert response.status_code == 201
     assert json.loads(response.data) == {"status": 201, "data": [{"id": 1,"name": "new updated party"}]}
+
+
+# test to delete a political party
+def test_delete_political_party(client):
+    """ Test deletion of a political party """
+    response = client.delete('/api/v1/delete-political-party/1')
+    assert response.status_code == 201
+    assert json.loads(response.data) == {"status": 201, "message": ["deletion successful"]}
+    response = client.delete('/api/v1/delete-political-party/78')
+    assert response.status_code == 400


### PR DESCRIPTION
# Description
This API enables the admin to delete a specific political party by **visiting**:
`http://127.0.0.1:5000/api/v1/delete-political-party/1`

## Checklist:
* Added tests to verify the URL and response data.
* Added module to take care of URL and value validation.
* Integrated API to delete a specific political party.

## Pivotal Tracker Story
https://www.pivotaltracker.com/story/show/163682802

## Image:

![delete-pp](https://user-images.githubusercontent.com/8969346/52430909-33d02800-2b18-11e9-8ef5-6d81d16b8042.jpg)

